### PR TITLE
Add manual CVSS override

### DIFF
--- a/scripts/html_2_tex.py
+++ b/scripts/html_2_tex.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+from html.parser import HTMLParser
+
+
+TEXT_ESCAPE_MAP = {
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\textasciicircum{}",
+}
+
+URL_ESCAPE_MAP = {
+    "%": r"\%",
+    "#": r"\#",
+    "&": r"\&",
+    "{": r"\{",
+    "}": r"\}",
+}
+
+
+def escape_latex_text(text: str) -> str:
+    pieces: list[str] = []
+    i = 0
+
+    while i < len(text):
+        ch = text[i]
+
+        # Preserve existing LaTeX commands and already-escaped characters.
+        if ch == "\\":
+            if i + 1 < len(text):
+                nxt = text[i + 1]
+                if nxt.isalpha():
+                    j = i + 2
+                    while j < len(text) and text[j].isalpha():
+                        j += 1
+                    pieces.append(text[i:j])
+                    i = j
+                    continue
+                if nxt in TEXT_ESCAPE_MAP or nxt in ["\\", " ", "[", "]"]:
+                    pieces.append(text[i:i + 2])
+                    i += 2
+                    continue
+
+            pieces.append(r"\textbackslash{}")
+            i += 1
+            continue
+
+        pieces.append(TEXT_ESCAPE_MAP.get(ch, ch))
+        i += 1
+
+    return "".join(pieces)
+
+
+def escape_latex_url(url: str) -> str:
+    pieces: list[str] = []
+    i = 0
+    while i < len(url):
+        ch = url[i]
+        if ch == "\\" and i + 1 < len(url) and url[i + 1] in {"%", "#", "&", "{", "}", "_"}:
+            pieces.append(url[i : i + 2])
+            i += 2
+            continue
+        if ch == "\\":
+            pieces.append(r"\textbackslash{}")
+        else:
+            pieces.append(URL_ESCAPE_MAP.get(ch, ch))
+        i += 1
+    return "".join(pieces)
+
+
+class HtmlToLatexParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.pre_parts: list[str] = []
+        self.in_pre = False
+        self.in_inline_code = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = dict(attrs)
+
+        if tag == "div":
+            return
+        if tag == "br":
+            self.parts.append("\\bigskip\n")
+            return
+        if tag in {"b", "strong"}:
+            self.parts.append(r"\textbf{")
+            return
+        if tag in {"i", "em"}:
+            self.parts.append(r"\textit{")
+            return
+        if tag == "ul":
+            self.parts.append("\\begin{itemize}\n")
+            return
+        if tag == "ol":
+            self.parts.append("\\begin{enumerate}\n")
+            return
+        if tag == "li":
+            self.parts.append("\\item ")
+            return
+        if tag == "pre":
+            self.in_pre = True
+            self.pre_parts = []
+            return
+        if tag == "code":
+            if self.in_pre:
+                return
+            self.in_inline_code = True
+            self.parts.append(r"\texttt{\detokenize{")
+            return
+        if tag == "a":
+            href = escape_latex_url(attr_map.get("href") or "")
+            self.parts.append(f"\\href{{{href}}}{{")
+            return
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "div":
+            self.parts.append("\n\n")
+            return
+        if tag in {"b", "strong", "i", "em", "a"}:
+            self.parts.append("}")
+            return
+        if tag == "ul":
+            self.parts.append("\n\\end{itemize}")
+            return
+        if tag == "ol":
+            self.parts.append("\n\\end{enumerate}")
+            return
+        if tag == "pre":
+            content = "".join(self.pre_parts).strip("\n")
+            self.parts.append("\\begin{verbatim}\n")
+            self.parts.append(content)
+            self.parts.append("\n\\end{verbatim}\n")
+            self.in_pre = False
+            self.pre_parts = []
+            return
+        if tag == "code" and not self.in_pre:
+            self.in_inline_code = False
+            self.parts.append("}}")
+
+    def handle_data(self, data: str) -> None:
+        data = data.replace("\xa0", " ")
+        if self.in_pre:
+            self.pre_parts.append(data)
+            return
+        if self.in_inline_code:
+            self.parts.append(data)
+            return
+        self.parts.append(escape_latex_text(data))
+
+    def get_output(self) -> str:
+        rendered = "".join(self.parts)
+        lines = [line.rstrip() for line in rendered.splitlines()]
+        return "\n".join(lines).strip() + ("\n" if rendered else "")
+
+
+def main() -> int:
+    parser = HtmlToLatexParser()
+    parser.feed(sys.stdin.read())
+    parser.close()
+    sys.stdout.write(parser.get_output())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/html_2_tex.sh
+++ b/scripts/html_2_tex.sh
@@ -1,45 +1,6 @@
 #!/bin/sh
 
-# Read from stdin, write to stdout
-sed -E '
-  # 1) Remove opening <div>
-  s/<div>//g
-
-  # 2) Replace closing </div> with two newlines
-  s#</div>#\n\n#g
-
-  # 3) Replace <br> (any form) with \bigskip
-  s#<br ?/?>#\\bigskip#g
-
-  # 4) <b>content</b> -> \textbf{content}
-  s#<b>([^<]*)</b>#\\textbf{\1}#g
-
-  # 5) <i>content</i> -> \textit{content}
-  s#<i>([^<]*)</i>#\\textit{\1}#g
-
-  # 6) <ul> -> \begin{itemize}, </ul> -> \end{itemize}
-  s#<ul>#\\begin{itemize}#g
-  s#</ul>#\\end{itemize}#g
-
-  # 7) <ol> -> \begin{enumerate}, </ol> -> \end{itemize} (per your spec)
-  s#<ol>#\\begin{enumerate}#g
-  s#</ol>#\\end{enumerate}#g
-
-  # 8) <li>content</li> -> \item content
-  s#<li>([^<]*)</li>#\\item \1#g
-
-  # 9) <pre><code>content</code></pre> -> \begin{verbatim} content \end{verbatim}
-  #    This is kept simple (single block)
-  s#<pre><code>#\\begin{verbatim}\n#g
-  s#</code></pre>#\n\\end{verbatim}#g
-
-  # 10) <code>content</code> -> \texttt{content} (for inline code)
-  s#<code>([^<]*)</code>#\\texttt{\1}#g
-
-  # 11) <a href="link">content</a> -> \href{link}{content}
-  s#<a href="([^"]*)">([^<]*)</a>#\\href{\1}{\2}#g
-
-  # 12) Decode &nbsp; as a space (optional)
-  s/&nbsp;/ /g
-'
+# Preserve the original shell entrypoint used by the report-generation pipeline, actual conversion logic lives in Python because robust
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/html_2_tex.py"
 

--- a/static/app.js
+++ b/static/app.js
@@ -11,14 +11,99 @@ const FILE_FIELDS = [
 let currentFinding = null;
 let allPrewriteOptions = null;
 
+const cvssOverrideEnabled = () => document.getElementById("cvss-override-enabled");
+const cvssOverrideScore = () => document.getElementById("cvss-override-score");
+
 var c = new CVSS("cvssboard", {
     onchange: function() {
         window.location.hash = c.get().vector;
-        c.vector.setAttribute('href', '#' + c.get().vector)
+        c.vector.setAttribute('href', '#' + c.get().vector);
+        applyCVSSScoreDisplay();
     }
 });
 if (window.location.hash.substring(1).length > 0) {
     c.set(decodeURIComponent(window.location.hash.substring(1)));
+}
+
+function normalizeCVSSOverrideScore(value) {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 10) {
+    return "";
+  }
+
+  return parsed.toFixed(1);
+}
+
+function setCVSSSeverityForScore(scoreValue) {
+  const parsed = Number.parseFloat(scoreValue);
+  if (Number.isNaN(parsed)) {
+    c.severity.className = "severity";
+    c.severity.textContent = "?";
+    c.severity.title = "Not defined";
+    return;
+  }
+
+  const rating = c.severityRating(parsed);
+  c.severity.className = `${rating.name} severity`;
+  c.severity.innerHTML = `${rating.name}<sub>${rating.bottom} - ${rating.top}</sub>`;
+  c.severity.title = `${rating.bottom} - ${rating.top}`;
+}
+
+function getManualCVSSOverride() {
+  const enabled = cvssOverrideEnabled();
+  const scoreInput = cvssOverrideScore();
+
+  if (!enabled || !scoreInput || !enabled.checked) {
+    return "";
+  }
+
+  return normalizeCVSSOverrideScore(scoreInput.value);
+}
+
+function setManualCVSSOverride(value) {
+  const enabled = cvssOverrideEnabled();
+  const scoreInput = cvssOverrideScore();
+  if (!enabled || !scoreInput) return;
+
+  const normalized = normalizeCVSSOverrideScore(value);
+  enabled.checked = normalized !== "";
+  scoreInput.disabled = !enabled.checked;
+  scoreInput.value = normalized;
+}
+
+function clearManualCVSSOverride() {
+  setManualCVSSOverride("");
+}
+
+function applyCVSSScoreDisplay() {
+  const calculatedScore = c.calculate();
+  const overrideScore = getManualCVSSOverride();
+  const displayedScore = overrideScore || calculatedScore;
+
+  c.score.textContent = displayedScore;
+  setCVSSSeverityForScore(displayedScore);
+}
+
+function validateManualCVSSOverride() {
+  const enabled = cvssOverrideEnabled();
+  const scoreInput = cvssOverrideScore();
+  if (!enabled || !scoreInput || !enabled.checked) {
+    return true;
+  }
+
+  const normalized = normalizeCVSSOverrideScore(scoreInput.value);
+  if (!normalized) {
+    setStatus("Manual CVSS override must be between 0.0 and 10.0", true);
+    scoreInput.focus();
+    return false;
+  }
+
+  scoreInput.value = normalized;
+  return true;
 }
 
 async function loadPrewrites() {
@@ -200,20 +285,39 @@ function deleteRow(button) {
 }
 
 function serializeCVSS() {
+  if (!validateManualCVSSOverride()) {
+    throw new Error("Manual CVSS override is invalid");
+  }
+
   const cvssData = c.get();
-  return `{${cvssData.score}}{${cvssData.likelihood}}{${cvssData.impact}}{${cvssData.vector}}`;
+  const override = getManualCVSSOverride();
+  const score = override || normalizeCVSSOverrideScore(cvssData.score) || cvssData.score;
+  return `{${score}}{${cvssData.likelihood}}{${cvssData.impact}}{${cvssData.vector}}{${override}}`;
 }
 
 function deserializeCVSS(serialized) {
   const m = serialized.match(/\{([^}]*)\}/g) || [];
-  if (m.length < 4) return;
+  if (m.length < 4) {
+    clearManualCVSSOverride();
+    applyCVSSScoreDisplay();
+    return;
+  }
 
   const score      = m[0].slice(1, -1);
   const likelihood = m[1].slice(1, -1);
   const impact     = m[2].slice(1, -1);
   const vector     = m[3].slice(1, -1);
+  const override   = m[4] ? m[4].slice(1, -1) : "";
 
   c.set({ score, likelihood, impact, vector });
+  if (override) {
+    setManualCVSSOverride(override);
+  } else if (normalizeCVSSOverrideScore(score) && normalizeCVSSOverrideScore(score) !== normalizeCVSSOverrideScore(c.calculate())) {
+    setManualCVSSOverride(score);
+  } else {
+    clearManualCVSSOverride();
+  }
+  applyCVSSScoreDisplay();
 }
 
 function serializeIPsFromTable() {
@@ -368,6 +472,9 @@ async function saveCurrentFinding() {
     setStatus("No finding selected", true);
     return;
   }
+  if (!validateManualCVSSOverride()) {
+    return;
+  }
 
   const payload = { files: {} };
   FILE_FIELDS.forEach(fname => {
@@ -398,6 +505,9 @@ async function saveField(fieldName) {
   
   let payload;
   const saveBtn = event.target;
+  if (!validateManualCVSSOverride()) {
+    return;
+  }
   
   if (fieldName == 'cvs') {
     payload = { files: { [fieldName+'.txt']: serializeCVSS() } };
@@ -513,6 +623,34 @@ async function handleImageUpload(files) {
 }
 
 window.addEventListener("DOMContentLoaded", () => {
+  const overrideEnabled = cvssOverrideEnabled();
+  const overrideScoreInput = cvssOverrideScore();
+
+  if (overrideEnabled && overrideScoreInput) {
+    overrideEnabled.addEventListener("change", () => {
+      overrideScoreInput.disabled = !overrideEnabled.checked;
+      if (!overrideEnabled.checked) {
+        overrideScoreInput.value = "";
+      } else if (!normalizeCVSSOverrideScore(overrideScoreInput.value)) {
+        overrideScoreInput.value = normalizeCVSSOverrideScore(c.calculate());
+      }
+      applyCVSSScoreDisplay();
+    });
+
+    overrideScoreInput.addEventListener("input", () => {
+      applyCVSSScoreDisplay();
+    });
+
+    overrideScoreInput.addEventListener("blur", () => {
+      if (!overrideEnabled.checked) return;
+      const normalized = normalizeCVSSOverrideScore(overrideScoreInput.value);
+      if (normalized) {
+        overrideScoreInput.value = normalized;
+      }
+      applyCVSSScoreDisplay();
+    });
+  }
+
   document
     .getElementById("create-finding-btn")
     .addEventListener("click", createFinding);
@@ -555,5 +693,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   loadFindings().catch((e) => setStatus(e.message, true));
   loadPrewrites().catch((e) => console.error(e));
+  clearManualCVSSOverride();
+  applyCVSSScoreDisplay();
 });
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -268,6 +268,32 @@ body {
   text-align: center;
   align-content: center;
 }
+.cvss-override-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+.cvss-override-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: #333;
+}
+#cvss-override-score {
+  width: 88px;
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+#cvss-override-score:disabled {
+  background: #f3f3f3;
+  color: #888;
+}
 @media screen and (min-width: 720px) {
   #cvssboard {
     width: 640px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,6 +46,21 @@
 	  <button class="field-save-btn" data-field="cvs" title="Save CVSS">S</button>
 	</div>
         <div id="cvssboard"></div>
+        <div id="cvss-override-controls" class="cvss-override-controls">
+          <label class="cvss-override-toggle">
+            <input type="checkbox" id="cvss-override-enabled">
+            Use manual score override
+          </label>
+          <input
+            id="cvss-override-score"
+            type="number"
+            min="0.0"
+            max="10.0"
+            step="0.1"
+            placeholder="0.0"
+            disabled
+          >
+        </div>
       </div>
       <div class="field-section" style="width: 640px">
 	<div class="field-header">


### PR DESCRIPTION
## Summary
- add a manual CVSS score override control in the findings editor
- preserve the existing calculated vector, likelihood, and impact workflow
- keep saved CVSS data backward compatible while persisting override state for newer saves

Closes #1

## Testing
- manually verify the override can be toggled on and off
- verify overridden scores persist after saving and reloading a finding